### PR TITLE
Adds LOGG Vorbis loop headers from the samples

### DIFF
--- a/src/fsb/vorbis/rebuilder.hpp
+++ b/src/fsb/vorbis/rebuilder.hpp
@@ -37,6 +37,7 @@ public:
   // Rebuilds Vorbis headers and returns them as Ogg packets.
   static void rebuild_headers(
     int channels, int rate, std::uint32_t crc32,
+    std::uint32_t loop_start, std::uint32_t loop_end,
     ogg_packet_holder & id,
     ogg_packet_holder & comment,
     ogg_packet_holder & setup);
@@ -48,7 +49,8 @@ public:
   
   // Rebuilds comment header.
   static void rebuild_comment_header(
-    ogg_packet_holder & packet);
+    ogg_packet_holder & packet,
+    std::uint32_t loop_start, std::uint32_t loop_end);
   
   // Rebuilds setup header.
   static void rebuild_setup_header(

--- a/src/fsb/vorbis/rebuilder_test.cpp
+++ b/src/fsb/vorbis/rebuilder_test.cpp
@@ -91,7 +91,7 @@ TEST(rebuilder_test, rebuild_id_header) {
 TEST(rebuilder_test, rebuild_comment_header) {
   ogg_packet_holder op;
   
-  rebuilder::rebuild_comment_header(op);
+  rebuilder::rebuild_comment_header(op, 0, 20);
   
   ASSERT_EQ(0, op->b_o_s);
   ASSERT_EQ(0, op->e_o_s);
@@ -156,6 +156,7 @@ TEST_P(generate_and_rebuild_test, headers_are_equivalent) {
 
   rebuilder::rebuild_headers(
     channels, rate, crc32(generator.setup_header()),
+    0, 20,
     op_id_header, op_comment_header, op_setup_header);
 
   // Bitrate fields are not reconstructed, clear them before comparison.

--- a/src/fsb/vorbis/vorbis.cpp
+++ b/src/fsb/vorbis/vorbis.cpp
@@ -66,6 +66,10 @@ vorbis_comment_holder::vorbis_comment_holder() {
   vorbis_comment_init(&value);
 }
 
+void vorbis_comment_holder::add_tag(const char *tag, const char *contents) {
+  vorbis_comment_add_tag(&value, tag, contents);
+}
+
 vorbis_comment_holder::~vorbis_comment_holder() {
   vorbis_comment_clear(&value);
 }

--- a/src/fsb/vorbis/vorbis.hpp
+++ b/src/fsb/vorbis/vorbis.hpp
@@ -118,6 +118,8 @@ class vorbis_comment_holder {
 public:
   // Intializes vorbis_comment with vorbis_comment_init,
   vorbis_comment_holder();
+  // Add a tag-comment pair
+  void add_tag(const char *tag, const char *contents);
   // Clears vorbis_comment with vorbis_comment_clear.
   ~vorbis_comment_holder();
   


### PR DESCRIPTION
FSB archives can contain loop information for samples. There is a variant of the OGG format named LOGG, which is used by some game formats (and handled by vgmstream), and stores loop information in Vorbis comment fields.
This modification saves any found loop points into the output OGG files. A user just needs to rename them to LOGG to have vgmstream play them with proper loop points.