### PR TITLE
Option to not fail on unknown extra headers?

### DIFF
--- a/src/fsb/container.cpp
+++ b/src/fsb/container.cpp
@@ -159,7 +159,7 @@ sample container::read_sample_header(io::buffer_view & view) {
         view.skip(extra_length);
         break;
       default:
-        CHECK(false) << "Unexpected extra header type: " << type;
+        CHECK(false) << "Unexpected extra header type: " << int(type) << ", length: " << extra_length;
         view.skip(extra_length);
     }
   }

--- a/src/fsb/container.cpp
+++ b/src/fsb/container.cpp
@@ -159,7 +159,7 @@ sample container::read_sample_header(io::buffer_view & view) {
         view.skip(extra_length);
         break;
       default:
-        CHECK(false) << "Unexpected extra header type: " << int(type) << ", length: " << extra_length;
+        //CHECK(false) << "Unexpected extra header type: " << int(type) << ", length: " << extra_length;
         view.skip(extra_length);
     }
   }


### PR DESCRIPTION
I was using this utility to extract an FSB file from the game [Hades, from Supergiant Games](https://www.supergiantgames.com/games/hades/), specifically the voiceover file at `Content/Audio/FMOD/Build/Desktop/VO.fsb`.  This app ends up failing out, though, due to unknown header information.  I altered the check slightly (on line 162 of `src/fsb/container.cpp`) to report both the header ID and remaining length, like so:

```cpp
        CHECK(false) << "Unexpected extra header type: " << int(type) << ", length: " << extra_length;
```

... and the resulting failure looks like this:

```
pez@arrakis:/games/Steam/steamapps/common/Hades/Content/Audio/FMOD/Build/Desktop$ ~/git/fsb-vorbis-extractor/build/src/extractor -l VO.fsb 
F20220611 17:47:43.161165 298894 container.cpp:162] Check failed: false Unexpected extra header type: 8, length: 260
*** Check failure stack trace: ***
    @     0x7f1c7bc36183  google::LogMessage::Fail()
    @     0x7f1c7bc3b625  google::LogMessage::SendToLog()
    @     0x7f1c7bc35c59  google::LogMessage::Flush()
    @     0x7f1c7bc41450  google::LogMessageFatal::~LogMessageFatal()
    @     0x564a34beec15  fsb::container::read_sample_header()
    @     0x564a34bef20d  fsb::container::read_sample_headers()
    @     0x564a34befeb7  fsb::container::container()
    @     0x564a34beb461  main
    @     0x7f1c7b429290  (unknown)
    @     0x7f1c7b42934a  __libc_start_main
    @     0x564a34becd65  _start
    @              (nil)  (unknown)
Aborted (core dumped)
```

I wouldn't presume to imply that this PR should be merged as is -- all it does is comment out that check, when that's probably not what you'd actually want to do.  Still, it might be a jumping-off point.