### PR TITLE
Option to not fail on Vorbis header CRC32 errors?

### DIFF
--- a/src/fsb/vorbis/rebuilder.cpp
+++ b/src/fsb/vorbis/rebuilder.cpp
@@ -122,8 +122,8 @@ void rebuilder::rebuild_headers(
   
   const auto i =
     std::lower_bound(headers, headers_end, crc32, headers_info_crc32_less());
-  CHECK(i != headers_end && i->crc32 == crc32)
-    << "Headers with CRC-32 equal " << crc32 << " not found.";
+  /*CHECK(i != headers_end && i->crc32 == crc32)
+    << "Headers with CRC-32 equal " << crc32 << " not found.";*/
   
   rebuild_id_header(channels, rate, i->blocksize_short, i->blocksize_long, id);
   rebuild_comment_header(comment, loop_start, loop_end);


### PR DESCRIPTION
I was using this utility to extract an FSB file from the game [Hades, from Supergiant Games](https://www.supergiantgames.com/games/hades/), specifically the voiceover file at `Content/Audio/FMOD/Build/Desktop/VO.fsb`.  Extracting that file requires some header-check tweaks that I described in PR #1, but after that, there's eight other files inside that `VO.fsb` which end up causing a crash in the program, specifically due to this check on line 125 of `src/fsb/vorbis/rebuilder.cpp`:

```cpp
  CHECK(i != headers_end && i->crc32 == crc32)
    << "Headers with CRC-32 equal " << crc32 << " not found.";
```

Specifically, the extraction process ends up failing out at:

```
Name:          Charon_0032
Frequency:     24000
Channels:      1
Offset:        104909472
Size:          6656
Vorbis CRC-32: 1783903935
Loop start:    0
Loop end:      0
Unknown:       143032

F20220611 17:56:15.309692 299572 rebuilder.cpp:125] Check failed: i != headers_end && i->crc32 == crc32 Headers with CRC-32 equal 1783903935 not found.
*** Check failure stack trace: ***
    @     0x7fbc4693e183  google::LogMessage::Fail()
    @     0x7fbc46943625  google::LogMessage::SendToLog()
    @     0x7fbc4693dc59  google::LogMessage::Flush()
    @     0x7fbc46949450  google::LogMessageFatal::~LogMessageFatal()
    @     0x55e32bfcf420  fsb::vorbis::rebuilder::rebuild_headers()
    @     0x55e32bfcf54a  fsb::vorbis::rebuilder::rebuild()
    @     0x55e32bfc6f8f  fsb::container::extract_sample()
    @     0x55e32bfc4215  main
    @     0x7fbc46029290  (unknown)
    @     0x7fbc4602934a  __libc_start_main
    @     0x55e32bfc4d55  _start
    @              (nil)  (unknown)
Aborted (core dumped)
```

If I comment out that check entirely (which is what this PR does), the files generated which would've tripped the check are, indeed, corrupt somehow -- it's just a bunch of electronic noise rather than the voiceover it should be.  However, bypassing the check *does* at least let me extract the remainder of the FSB, rather than having it die at the one that's failed.  Having eight corrupt `.ogg` files out of 19,597, in this case, doesn't seem like the worst thing.

So really what I think would be useful is some kind of `--ignore-error` option.  Perhaps save a list of "failed" files while running, and report them at the end, so it's easier to see them?  It might make sense to simply Not Extract those specific files, too, rather than leaving a weirdly corrupt version behind.

My own C++ was never great and is currently atrophied to the point of near uselessness, so I'm not really the one to provide a full merge-worthy PR for this, but figured I could at least catalogue the problem.  FWIW, the Python-based [python-fsb5](https://github.com/HearthSim/python-fsb5) *does* extract these eight files properly, so it could be there's something in there which could be useful, though I think it uses third-party libraries to do the Vorbis processing.

For record, here's the eight cues which end up getting corrupted (and which halt the process of extraction, without commenting out the check here):

* `Charon_0032` 
* `Charon_0038` 
* `Intercom_0097` 
* `Intercom_0312` 
* `Intercom_0419` 
* `Intercom_0857` 
* `Nyx_0255` 
* `Tisiphone_0075` 
