### PR TITLE
Downgrading several fatal messages to allow extraction

### DIFF
--- a/src/fsb/container.cpp
+++ b/src/fsb/container.cpp
@@ -159,7 +159,7 @@ sample container::read_sample_header(io::buffer_view & view) {
         view.skip(extra_length);
         break;
       default:
-        CHECK(false) << "Unexpected extra header type: " << type;
+        LOG_FIRST_N(WARNING, 10) << "Skipping unknown sample header information with type 0x" << std::hex << int(type);
         view.skip(extra_length);
     }
   }

--- a/src/fsb/extractor.cpp
+++ b/src/fsb/extractor.cpp
@@ -103,7 +103,9 @@ void print_sample(std::ostream & os, const fsb::sample & sample) {
 }
 
 int main(int argc, char **argv) {
+  FLAGS_stderrthreshold = 0;
   google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
 
   const extractor_options options = parse_options(argc, argv);
   
@@ -122,6 +124,7 @@ int main(int argc, char **argv) {
     for (auto & sample : container.samples()) {
       sample_number += 1;
       
+      std::cout << sample_number << std::endl;
       print_sample(std::cout, sample);
       std::cout << std::endl;
       

--- a/src/fsb/vorbis/rebuilder.cpp
+++ b/src/fsb/vorbis/rebuilder.cpp
@@ -119,11 +119,10 @@ void rebuilder::rebuild_headers(
   ogg_packet_holder & id,
   ogg_packet_holder & comment,
   ogg_packet_holder & setup) {
-  
   const auto i =
     std::lower_bound(headers, headers_end, crc32, headers_info_crc32_less());
-  CHECK(i != headers_end && i->crc32 == crc32)
-    << "Headers with CRC-32 equal " << crc32 << " not found.";
+  LOG_IF(ERROR, i == headers_end || i->crc32 != crc32)
+    << "CRC " << crc32 << " not found in headers.inc. Using arbitrary code book. The file may be unplayable.";
   
   rebuild_id_header(channels, rate, i->blocksize_short, i->blocksize_long, id);
   rebuild_comment_header(comment, loop_start, loop_end);


### PR DESCRIPTION
My file has 0x10 headers on all samples. That is not fatal

Ten of 4000 samples has an unknown crc. That only applies to those samples that may or may not be playable with an arbitrary header applied

The test file is speech-english.fsb and can be obtained from steamcmd download_depot 378540 378544